### PR TITLE
Accommodate subjects with missing vertebral levels on anatomical scan

### DIFF
--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -300,7 +300,7 @@ for file_dwi in "${files_dwi[@]}"; do
     done
   done
   # Output file levels.csv to check the correspondance between vertebral levels and slices for each chunk
-  sct_extract_metric -i ${file_dwi}_FA.nii.gz -l 51 -f label_${file_dwi}/atlas/ -vert 1:12 -perlevel 1 -vertfile label_${file_dwi}/template/PAM50_levels.nii.gz -o levels.csv -append 1
+  sct_extract_metric -i ${file_dwi}_FA.nii.gz -l 51 -f label_${file_dwi}/atlas/ -vert "${vertebral_levels}" -perlevel 1 -vertfile label_${file_dwi}/template/PAM50_levels.nii.gz -o levels.csv -append 1
 done
 
 # TODO

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -62,7 +62,6 @@ label_if_does_not_exist() {
 
   local file="${1}"
   local file_seg="${2}"
-  local label_values="${3}"
   # Update global variable with segmentation file name
   FILELABEL="${file}"_label-vertebrae
   FILELABELDISC="${file}"_label-disc
@@ -140,7 +139,7 @@ echo "👉 Processing: ${file_t2}"
 segment_if_does_not_exist "${file_t2}" "t2"
 file_t2_seg="${FILESEG}"
 # Create labels in the cord at mid-vertebral levels
-label_if_does_not_exist "${file_t2}" "${file_t2_seg}" "2,12"
+label_if_does_not_exist "${file_t2}" "${file_t2_seg}"
 file_label="${FILELABEL}"
 # Register to template
 sct_register_to_template -i "${file_t2}".nii.gz -s "${file_t2_seg}".nii.gz -ldisc "${file_label}".nii.gz -c t2 \
@@ -156,160 +155,160 @@ sct_process_segmentation -i "${file_t2_seg}".nii.gz -vert "${vertebral_levels}" 
 python ${PATH_SCRIPT}/format_csv.py "${PATH_RESULTS}"/CSA.csv
 
 
-# MT
-# =====================================================================================================================
-file_mt1="${SUBJECT}"_mt-on_MTS
-file_mt0="${SUBJECT}"_mt-off_MTS
-echo "👉 Processing: ${file_mt0}"
-# Segment spinal cord
-segment_if_does_not_exist "${file_mt0}" "t1"
-file_mt0_seg="${FILESEG}"
-# Crop data for faster processing
-sct_crop_image -i "${file_mt0}".nii.gz -m "${file_mt0_seg}".nii.gz -dilate 10x10x0 -o "${file_mt0}"_crop.nii.gz
-sct_crop_image -i "${file_mt0_seg}".nii.gz -m "${file_mt0_seg}".nii.gz -dilate 10x10x0 -o "${file_mt0}"_crop_seg.nii.gz
-file_mt0="${file_mt0}"_crop
-# Register mt1->mt0
-# Tips: here we only use rigid transformation because both images have very
-# similar sequence parameters. We don't want to use SyN/BSplineSyN to avoid
-# introducing spurious deformations.
-sct_register_multimodal -i "${file_mt1}".nii.gz \
-                        -d "${file_mt0}".nii.gz \
-                        -dseg "${file_mt0}"_seg.nii.gz \
-                        -param step=1,type=im,algo=rigid,slicewise=1,metric=CC \
-                        -x spline \
-                        -qc "${PATH_QC}"
-# Register template->mt0
-# Tips: First step: slicereg based on images, with large smoothing to capture potential motion between anat and mt, then 
-# at second step: bpslinesyn in order to adapt the shape of the cord to the mt modality (in case there are distortions 
-# between anat and mt).
-sct_register_multimodal -i "${SCT_DIR}"/data/PAM50/template/PAM50_t1.nii.gz \
-                        -iseg "${SCT_DIR}"/data/PAM50/template/PAM50_cord.nii.gz \
-                        -d "${file_mt0}".nii.gz \
-                        -dseg "${file_mt0}"_seg.nii.gz \
-                        -param step=1,type=seg,algo=centermass:step=2,type=im,algo=bsplinesyn,slicewise=1,iter=3 \
-                        -initwarp warp_template2anat.nii.gz \
-                        -initwarpinv warp_anat2template.nii.gz \
-                        -qc "${PATH_QC}"
-# Rename warping fields for clarity
-mv warp_PAM50_t12"${file_mt0}".nii.gz warp_template2mt.nii.gz
-mv warp_"${file_mt0}"2PAM50_t1.nii.gz warp_mt2template.nii.gz
-# Warp template
-sct_warp_template -d "${file_mt0}".nii.gz -w warp_template2mt.nii.gz -ofolder label_MT -qc "${PATH_QC}"
-# Compute mtr
-sct_compute_mtr -mt0 "${file_mt0}".nii.gz -mt1 "${file_mt1}"_reg.nii.gz
-# compute MTR in various tracts
-for tract in ${tracts[@]}; do
-  file_out=${PATH_RESULTS}/MTR_${tract//,/-}.csv
-  sct_extract_metric -i mtr.nii.gz -f label_MT/atlas -l ${tract} -combine 1 -vert "${vertebral_levels}" -vertfile label_MT/template/PAM50_levels.nii.gz -perlevel 1 -method map -o ${file_out} -append 1
-  # Format CSV file
-  python ${PATH_SCRIPT}/format_csv.py ${file_out}
-done
+# # MT
+# # =====================================================================================================================
+# file_mt1="${SUBJECT}"_mt-on_MTS
+# file_mt0="${SUBJECT}"_mt-off_MTS
+# echo "👉 Processing: ${file_mt0}"
+# # Segment spinal cord
+# segment_if_does_not_exist "${file_mt0}" "t1"
+# file_mt0_seg="${FILESEG}"
+# # Crop data for faster processing
+# sct_crop_image -i "${file_mt0}".nii.gz -m "${file_mt0_seg}".nii.gz -dilate 10x10x0 -o "${file_mt0}"_crop.nii.gz
+# sct_crop_image -i "${file_mt0_seg}".nii.gz -m "${file_mt0_seg}".nii.gz -dilate 10x10x0 -o "${file_mt0}"_crop_seg.nii.gz
+# file_mt0="${file_mt0}"_crop
+# # Register mt1->mt0
+# # Tips: here we only use rigid transformation because both images have very
+# # similar sequence parameters. We don't want to use SyN/BSplineSyN to avoid
+# # introducing spurious deformations.
+# sct_register_multimodal -i "${file_mt1}".nii.gz \
+#                         -d "${file_mt0}".nii.gz \
+#                         -dseg "${file_mt0}"_seg.nii.gz \
+#                         -param step=1,type=im,algo=rigid,slicewise=1,metric=CC \
+#                         -x spline \
+#                         -qc "${PATH_QC}"
+# # Register template->mt0
+# # Tips: First step: slicereg based on images, with large smoothing to capture potential motion between anat and mt, then 
+# # at second step: bpslinesyn in order to adapt the shape of the cord to the mt modality (in case there are distortions 
+# # between anat and mt).
+# sct_register_multimodal -i "${SCT_DIR}"/data/PAM50/template/PAM50_t1.nii.gz \
+#                         -iseg "${SCT_DIR}"/data/PAM50/template/PAM50_cord.nii.gz \
+#                         -d "${file_mt0}".nii.gz \
+#                         -dseg "${file_mt0}"_seg.nii.gz \
+#                         -param step=1,type=seg,algo=centermass:step=2,type=im,algo=bsplinesyn,slicewise=1,iter=3 \
+#                         -initwarp warp_template2anat.nii.gz \
+#                         -initwarpinv warp_anat2template.nii.gz \
+#                         -qc "${PATH_QC}"
+# # Rename warping fields for clarity
+# mv warp_PAM50_t12"${file_mt0}".nii.gz warp_template2mt.nii.gz
+# mv warp_"${file_mt0}"2PAM50_t1.nii.gz warp_mt2template.nii.gz
+# # Warp template
+# sct_warp_template -d "${file_mt0}".nii.gz -w warp_template2mt.nii.gz -ofolder label_MT -qc "${PATH_QC}"
+# # Compute mtr
+# sct_compute_mtr -mt0 "${file_mt0}".nii.gz -mt1 "${file_mt1}"_reg.nii.gz
+# # compute MTR in various tracts
+# for tract in ${tracts[@]}; do
+#   file_out=${PATH_RESULTS}/MTR_${tract//,/-}.csv
+#   sct_extract_metric -i mtr.nii.gz -f label_MT/atlas -l ${tract} -combine 1 -vert "${vertebral_levels}" -vertfile label_MT/template/PAM50_levels.nii.gz -perlevel 1 -method map -o ${file_out} -append 1
+#   # Format CSV file
+#   python ${PATH_SCRIPT}/format_csv.py ${file_out}
+# done
 
 
-# MP2RAGE
-# =====================================================================================================================
-file_uni="${SUBJECT}"_UNIT1
-file_t1="${SUBJECT}"_T1map
-echo "👉 Processing: ${file_uni}"
-# Segment spinal cord
-segment_if_does_not_exist "${file_uni}" "t1"
-file_uni_seg="${FILESEG}"
-# Crop data for faster processing
-sct_crop_image -i "${file_uni}".nii.gz -m "${file_uni_seg}".nii.gz -dilate 5x5x0 -o "${file_uni}"_crop.nii.gz
-file_uni="${file_uni}"_crop
-sct_crop_image -i "${file_t1}".nii.gz -m "${file_uni_seg}".nii.gz -dilate 5x5x0 -o "${file_t1}"_crop.nii.gz
-file_t1="${file_t1}"_crop
-# Register template->UNIT1
-sct_register_multimodal -i "${SCT_DIR}"/data/PAM50/template/PAM50_t1.nii.gz \
-                        -iseg "${SCT_DIR}"/data/PAM50/template/PAM50_cord.nii.gz \
-                        -d "${file_uni}".nii.gz \
-                        -dseg "${file_uni_seg}".nii.gz \
-                        -param step=1,type=seg,algo=centermass:step=2,type=im,algo=bsplinesyn,slicewise=0,iter=3 \
-                        -initwarp warp_template2anat.nii.gz \
-                        -initwarpinv warp_anat2template.nii.gz \
-                        -qc "${PATH_QC}"
-# Rename warping fields for clarity
-mv warp_PAM50_t12"${file_uni}".nii.gz warp_template2t1.nii.gz
-mv warp_"${file_uni}"2PAM50_t1.nii.gz warp_t12template.nii.gz
-# Warp template
-sct_warp_template -d "${file_uni}".nii.gz -w warp_template2t1.nii.gz -ofolder label_T1 -qc "${PATH_QC}"
-# compute T1 in various tracts
-for tract in ${tracts[@]}; do
-  file_out=${PATH_RESULTS}/T1_${dti_metric}_${tract//,/-}.csv
-  sct_extract_metric -i "${file_t1}".nii.gz -f label_T1/atlas -l ${tract} -combine 1 -vert "${vertebral_levels}" -vertfile label_T1/template/PAM50_levels.nii.gz -perlevel 1 -method map -o ${file_out} -append 1
-  # Format CSV file
-  python ${PATH_SCRIPT}/format_csv.py ${file_out}
-done
+# # MP2RAGE
+# # =====================================================================================================================
+# file_uni="${SUBJECT}"_UNIT1
+# file_t1="${SUBJECT}"_T1map
+# echo "👉 Processing: ${file_uni}"
+# # Segment spinal cord
+# segment_if_does_not_exist "${file_uni}" "t1"
+# file_uni_seg="${FILESEG}"
+# # Crop data for faster processing
+# sct_crop_image -i "${file_uni}".nii.gz -m "${file_uni_seg}".nii.gz -dilate 5x5x0 -o "${file_uni}"_crop.nii.gz
+# file_uni="${file_uni}"_crop
+# sct_crop_image -i "${file_t1}".nii.gz -m "${file_uni_seg}".nii.gz -dilate 5x5x0 -o "${file_t1}"_crop.nii.gz
+# file_t1="${file_t1}"_crop
+# # Register template->UNIT1
+# sct_register_multimodal -i "${SCT_DIR}"/data/PAM50/template/PAM50_t1.nii.gz \
+#                         -iseg "${SCT_DIR}"/data/PAM50/template/PAM50_cord.nii.gz \
+#                         -d "${file_uni}".nii.gz \
+#                         -dseg "${file_uni_seg}".nii.gz \
+#                         -param step=1,type=seg,algo=centermass:step=2,type=im,algo=bsplinesyn,slicewise=0,iter=3 \
+#                         -initwarp warp_template2anat.nii.gz \
+#                         -initwarpinv warp_anat2template.nii.gz \
+#                         -qc "${PATH_QC}"
+# # Rename warping fields for clarity
+# mv warp_PAM50_t12"${file_uni}".nii.gz warp_template2t1.nii.gz
+# mv warp_"${file_uni}"2PAM50_t1.nii.gz warp_t12template.nii.gz
+# # Warp template
+# sct_warp_template -d "${file_uni}".nii.gz -w warp_template2t1.nii.gz -ofolder label_T1 -qc "${PATH_QC}"
+# # compute T1 in various tracts
+# for tract in ${tracts[@]}; do
+#   file_out=${PATH_RESULTS}/T1_${dti_metric}_${tract//,/-}.csv
+#   sct_extract_metric -i "${file_t1}".nii.gz -f label_T1/atlas -l ${tract} -combine 1 -vert "${vertebral_levels}" -vertfile label_T1/template/PAM50_levels.nii.gz -perlevel 1 -method map -o ${file_out} -append 1
+#   # Format CSV file
+#   python ${PATH_SCRIPT}/format_csv.py ${file_out}
+# done
 
 
-# DWI
-# =====================================================================================================================
-# For each slab:
-# • Average DWI scans
-# • Segment spinal cord on mean DWI scan
-# • Create mask
-# • Motion correction
-# • Average DWI scan
-# • Segment spinal cord on mean DWI_moco scan
-# • Register to PAM50 via T2w registration
-# • Compute DTI metrics for all slices within various tracts/regions
-# Then:
-# DWI merging of slabs:
-# • Use a script that will combine the three CSV files (one per slab, with some overlap) and that will average the DTI 
-#   metrics within each vertebral level that exists across the three CSV files.
-cd ../dwi/
-# Get file names for every acquired chunks of DWI data
-files_dwi=(`ls "${SUBJECT}"_chunk-*_DWI.nii.gz`)
-for file_dwi in "${files_dwi[@]}"; do
-  echo "👉 Processing: ${file_dwi}"
-  file_dwi="${file_dwi%.nii.gz}"
-  file_bvec=${file_dwi}.bvec
-  file_bval=${file_dwi}.bval
-  # Separate b=0 and DW images
-  sct_dmri_separate_b0_and_dwi -i ${file_dwi}.nii.gz -bvec ${file_bvec}
-  # Segment spinal cord
-  segment_if_does_not_exist "${file_dwi}"_dwi_mean "dwi"
-  file_dwi_seg="${FILESEG}"
-  # Crop data for faster processing
-  sct_crop_image -i "${file_dwi}".nii.gz -m "${file_dwi_seg}".nii.gz -dilate 15x15x0 -o "${file_dwi}"_crop.nii.gz
-  file_dwi=${file_dwi}_crop
-  # Motion correction
-  sct_dmri_moco -i ${file_dwi}.nii.gz -bvec ${file_bvec} -x spline
-  file_dwi=${file_dwi}_moco
-  file_dwi_mean=${file_dwi}_dwi_mean
-  # Segment spinal cord (only if it does not exist)
-  segment_if_does_not_exist ${file_dwi_mean} "dwi"
-  file_dwi_seg=$FILESEG
-  # Register template->dwi (using T2w-to-template as initial transformation)
-  sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz \
-                          -iseg $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz \
-                          -d ${file_dwi_mean}.nii.gz -dseg ${file_dwi_seg}.nii.gz \
-                          -param step=1,type=seg,algo=centermass:step=2,type=im,algo=bsplinesyn,metric=CC,slicewise=1,iter=3,gradStep=0.5 \
-                          -initwarp ../anat/warp_template2anat.nii.gz -initwarpinv ../anat/warp_anat2template.nii.gz \
-                          -qc "${PATH_QC}"
-  # Warp template
-  sct_warp_template -d ${file_dwi_mean}.nii.gz -w warp_PAM50_t12${file_dwi_mean}.nii.gz -ofolder label_${file_dwi} -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  # Compute DTI
-  sct_dmri_compute_dti -i ${file_dwi}.nii.gz -bvec ${file_bvec} -bval ${file_bval} -method standard -o ${file_dwi}_
-  # Compute DTI metrics in various tracts
-  dti_metrics=(FA MD RD AD)
-  for dti_metric in ${dti_metrics[@]}; do
-    for tract in ${tracts[@]}; do
-      file_out=${PATH_RESULTS}/DWI_${dti_metric}_${tract//,/-}.csv
-      sct_extract_metric -i ${file_dwi}_${dti_metric}.nii.gz -f label_${file_dwi}/atlas -l ${tract} -combine 1 -vert "${vertebral_levels}" -vertfile label_${file_dwi}/template/PAM50_levels.nii.gz -perlevel 1 -method map -o ${file_out} -append 1
-      # Aggregate metrics across vertebral levels pertaining to adjacent chunks
-      python ${PATH_SCRIPT}/aggregate_chunks.py ${file_out} --output-csv ${PATH_RESULTS}/DWI_${dti_metric}_${tract//,/-}_aggregated.csv
-    done
-  done
-  # Output file levels.csv to check the correspondance between vertebral levels and slices for each chunk
-  sct_extract_metric -i ${file_dwi}_FA.nii.gz -l 51 -f label_${file_dwi}/atlas/ -vert 1:12 -perlevel 1 -vertfile label_${file_dwi}/template/PAM50_levels.nii.gz -o levels.csv -append 1
-done
+# # DWI
+# # =====================================================================================================================
+# # For each slab:
+# # • Average DWI scans
+# # • Segment spinal cord on mean DWI scan
+# # • Create mask
+# # • Motion correction
+# # • Average DWI scan
+# # • Segment spinal cord on mean DWI_moco scan
+# # • Register to PAM50 via T2w registration
+# # • Compute DTI metrics for all slices within various tracts/regions
+# # Then:
+# # DWI merging of slabs:
+# # • Use a script that will combine the three CSV files (one per slab, with some overlap) and that will average the DTI 
+# #   metrics within each vertebral level that exists across the three CSV files.
+# cd ../dwi/
+# # Get file names for every acquired chunks of DWI data
+# files_dwi=(`ls "${SUBJECT}"_chunk-*_DWI.nii.gz`)
+# for file_dwi in "${files_dwi[@]}"; do
+#   echo "👉 Processing: ${file_dwi}"
+#   file_dwi="${file_dwi%.nii.gz}"
+#   file_bvec=${file_dwi}.bvec
+#   file_bval=${file_dwi}.bval
+#   # Separate b=0 and DW images
+#   sct_dmri_separate_b0_and_dwi -i ${file_dwi}.nii.gz -bvec ${file_bvec}
+#   # Segment spinal cord
+#   segment_if_does_not_exist "${file_dwi}"_dwi_mean "dwi"
+#   file_dwi_seg="${FILESEG}"
+#   # Crop data for faster processing
+#   sct_crop_image -i "${file_dwi}".nii.gz -m "${file_dwi_seg}".nii.gz -dilate 15x15x0 -o "${file_dwi}"_crop.nii.gz
+#   file_dwi=${file_dwi}_crop
+#   # Motion correction
+#   sct_dmri_moco -i ${file_dwi}.nii.gz -bvec ${file_bvec} -x spline
+#   file_dwi=${file_dwi}_moco
+#   file_dwi_mean=${file_dwi}_dwi_mean
+#   # Segment spinal cord (only if it does not exist)
+#   segment_if_does_not_exist ${file_dwi_mean} "dwi"
+#   file_dwi_seg=$FILESEG
+#   # Register template->dwi (using T2w-to-template as initial transformation)
+#   sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz \
+#                           -iseg $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz \
+#                           -d ${file_dwi_mean}.nii.gz -dseg ${file_dwi_seg}.nii.gz \
+#                           -param step=1,type=seg,algo=centermass:step=2,type=im,algo=bsplinesyn,metric=CC,slicewise=1,iter=3,gradStep=0.5 \
+#                           -initwarp ../anat/warp_template2anat.nii.gz -initwarpinv ../anat/warp_anat2template.nii.gz \
+#                           -qc "${PATH_QC}"
+#   # Warp template
+#   sct_warp_template -d ${file_dwi_mean}.nii.gz -w warp_PAM50_t12${file_dwi_mean}.nii.gz -ofolder label_${file_dwi} -qc ${PATH_QC} -qc-subject ${SUBJECT}
+#   # Compute DTI
+#   sct_dmri_compute_dti -i ${file_dwi}.nii.gz -bvec ${file_bvec} -bval ${file_bval} -method standard -o ${file_dwi}_
+#   # Compute DTI metrics in various tracts
+#   dti_metrics=(FA MD RD AD)
+#   for dti_metric in ${dti_metrics[@]}; do
+#     for tract in ${tracts[@]}; do
+#       file_out=${PATH_RESULTS}/DWI_${dti_metric}_${tract//,/-}.csv
+#       sct_extract_metric -i ${file_dwi}_${dti_metric}.nii.gz -f label_${file_dwi}/atlas -l ${tract} -combine 1 -vert "${vertebral_levels}" -vertfile label_${file_dwi}/template/PAM50_levels.nii.gz -perlevel 1 -method map -o ${file_out} -append 1
+#       # Aggregate metrics across vertebral levels pertaining to adjacent chunks
+#       python ${PATH_SCRIPT}/aggregate_chunks.py ${file_out} --output-csv ${PATH_RESULTS}/DWI_${dti_metric}_${tract//,/-}_aggregated.csv
+#     done
+#   done
+#   # Output file levels.csv to check the correspondance between vertebral levels and slices for each chunk
+#   sct_extract_metric -i ${file_dwi}_FA.nii.gz -l 51 -f label_${file_dwi}/atlas/ -vert 1:12 -perlevel 1 -vertfile label_${file_dwi}/template/PAM50_levels.nii.gz -o levels.csv -append 1
+# done
 
-# TODO
-# Average metrics within vertebral levels from output CSV files
+# # TODO
+# # Average metrics within vertebral levels from output CSV files
 
-# Go back to parent folder
-cd ..
+# # Go back to parent folder
+# cd ..
 
 
 # Verify presence of output files and write log file if error


### PR DESCRIPTION
If some subjects have missing T5, the pipeline will fail because (i) T2 is used for registration to the template and (ii) T5 is used for extracting metrics.

The following PR accommodates various coverage using the following modifications to the code:

- [x] Use all disc labels _available on the subject_ for registration to template (not specifically C2-T5). 
- [x] Use disc instead of mid-vertebral labels for registration to template
- [x] Extract metric alongside the levels that exist in a given subject --> no need to https://github.com/sct-pipeline/spine-park/pull/49#issuecomment-2211786390

Fixes #45